### PR TITLE
PR: updating nbdev and adding add functionality

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -42,6 +42,7 @@
    "source": [
     "#export\n",
     "def add_one(val):\n",
+    "    print(val)\n",
     "    return val + 1"
    ]
   },
@@ -57,6 +58,13 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [

--- a/nbdev_playground/core.py
+++ b/nbdev_playground/core.py
@@ -4,6 +4,7 @@ __all__ = ['add_one', 'mult2', 'add_one', 'mult2']
 
 # Cell
 def add_one(val):
+    print(val)
     return val + 1
 
 # Cell
@@ -17,6 +18,7 @@ def mult2(voi):
 
 # Cell
 def add_one(val):
+    print(val)
     return val + 1
 
 # Cell


### PR DESCRIPTION
Here, I fixed the nbdev recursive keyword in the settings, but it fails because the repo setup.py doesn't know how to handle this keyword (old version)